### PR TITLE
Corrige erros de digitação

### DIFF
--- a/analise_lexica/analisador.tex
+++ b/analise_lexica/analisador.tex
@@ -6,7 +6,7 @@
         \item A análise léxica é a primeira fase de um compilador
         \pause
 
-        \item Um analisador léxico deve ser os caracteres da entrada e produzir uma sequência de tokens, os quais serão usados pelo \textit{parser} durante a
+        \item Um analisador léxico deve ler os caracteres da entrada e produzir uma sequência de tokens, os quais serão usados pelo \textit{parser} durante a
             análise sintática
         \pause
 
@@ -26,7 +26,7 @@
 \begin{frame}[fragile]{Interação entre o analisador léxico e o {\it parser}}
 
     \begin{figure}
-        \centering 
+        \centering
 
         \begin{tikzpicture}
             \node (A) at (0, 6) {\footnotesize \texttt{\begin{tabular}{c}programa\\ fonte\end{tabular}} };
@@ -53,8 +53,7 @@
         \item A separação entre estas duas fases pode simplificar uma das duas (ou ambas)
         \pause
 
-        \item A eficiência do compilador é melhorada, uma vez que a separação permite o uso de técnicas especializadas, como buferização, para melhorar o 
-            desempenho da leitura da entrada e extração de tokens
+        \item A eficiência do compilador é melhorada, uma vez que a separação permite o uso de técnicas especializadas, como buferização, para melhorar o desempenho da leitura da entrada e extração de tokens
         \pause
 
         \item A separação permite uma melhor portabilidade do compilador, uma vez que diferenças entre a captura da entrada e codificação de caracteres,

--- a/analise_lexica/buferizacao.tex
+++ b/analise_lexica/buferizacao.tex
@@ -29,8 +29,7 @@
             gerador
         \pause
 
-        \item Escrever o analisador léxico em alguma linguagemde programação convencional (C, C++, etc). A buferização fica atrelada aos mecanismos de I/O da
-            linguagem
+        \item Escrever o analisador léxico em alguma linguagem de programação convencional (C, C++, etc). A buferização fica atrelada aos mecanismos de I/O da linguagem
         \pause
 
         \item Escrever o analisador em linguagem de montagem e tratar explicitamente a leitura da entrada e a buferização
@@ -47,7 +46,7 @@
         \item Em geral, $N$ corresponde ao tamanho de um bloco do disco (por exemplo, 1024 ou 4096 caracteres)
         \pause
 
-        \item Cada metade do \textit{buffer} é preenchida de uma única vez, por meio da chamada de uma função de leitura dos sistema
+        \item Cada metade do \textit{buffer} é preenchida de uma única vez, por meio da chamada de uma função de leitura do sistema
         \pause
 
         \item Caso restem na entrada menos do que $N$ caracteres, é inserido um caractere especial no \textit{buffer} para indicar o fim da entrada
@@ -85,7 +84,7 @@
 \begin{frame}[fragile]{Atualização dos {\it buffers} e o ponteiro $R$}
 
     \begin{itemize}
-        \item Se o ponteiro $R$ tentar se deslocar para além do meio do \textit{buffer}, será preciso preencher a metade direita com $N$ novos caracteres antes 
+        \item Se o ponteiro $R$ tentar se deslocar para além do meio do \textit{buffer}, será preciso preencher a metade direita com $N$ novos caracteres antes
             deste avanço
         \pause
 
@@ -115,7 +114,7 @@
             \Comment{\textit{Assuma que os índices de {\it buffer} começem em zero}}
         \ElsIf{}
             \State{$R\gets R + 1$}
-        \EndIf 
+        \EndIf
     \end{algorithmic}
 
 \end{frame}
@@ -155,7 +154,7 @@
             \Else{}
                 \Comment{\textit{\code{cpp}{EOF} está no buffer, indicando o fim da entrada}}
                 \State{Finalize a análise léxica}
-            \EndIf 
+            \EndIf
         \EndIf
     \end{algorithmic}
 

--- a/visao_geral/analise.tex
+++ b/visao_geral/analise.tex
@@ -53,12 +53,12 @@
         \pause
 
         \begin{enumerate}[(a)]
-            \item Para o nó $n$, rotulado pelo não-terminal $A$, selecione uma das produções para $A$ e construa os filhos de $n$ com os símbolos do lado 
+            \item Para o nó $n$, rotulado pelo não-terminal $A$, selecione uma das produções para $A$ e construa os filhos de $n$ com os símbolos do lado
             direito da produção
             \pause
 
             \item Encontre o próximo nó no qual uma subárvore deve ser construída
-        \end{enumerate} 
+        \end{enumerate}
     \end{enumerate}
     \pause
 
@@ -92,7 +92,7 @@
     \pause
     \vspace{0.2in}
 
-    Observação: os dois pontos (`$..$') formam um único token. 
+    Observação: os dois pontos (`$..$') formam um único token.
 
 \end{frame}
 
@@ -108,9 +108,9 @@
         \pause
 
         \begin{center}
-           \begin{tikzpicture} 
+           \begin{tikzpicture}
                 \node (A) at (6, 6) { \footnotesize $tipo$ };
-           \end{tikzpicture} 
+           \end{tikzpicture}
         \end{center}
         \pause
 
@@ -119,7 +119,7 @@
         \pause
 
         \begin{center}
-           \begin{tikzpicture} 
+           \begin{tikzpicture}
                 \node (A) at (5, 5) { \footnotesize $tipo$ };
                 \node (B1) at (0, 3.5) { \footnotesize \code{pascal}{array} };
                 \node (B2) at (2, 3.5) { \footnotesize \code{pascal}{[} };
@@ -134,9 +134,9 @@
                 \draw[thick] (A) to (B4);
                 \draw[thick] (A) to (B5);
                 \draw[thick] (A) to (B6);
-           \end{tikzpicture} 
+           \end{tikzpicture}
         \end{center}
- 
+
     \end{enumerate}
 \end{frame}
 
@@ -157,7 +157,7 @@
         \pause
 
        \begin{center}
-           \begin{tikzpicture} 
+           \begin{tikzpicture}
                 \node (A) at (5, 5) { \footnotesize $tipo$ };
                 \node (B1) at (0, 3.75) { \footnotesize \code{pascal}{array} };
                 \node (B2) at (2, 3.75) { \footnotesize \code{pascal}{[} };
@@ -178,10 +178,10 @@
                 \draw[thick] (B3) to (C1);
                 \draw[thick] (B3) to (C2);
                 \draw[thick] (B3) to (C3);
-        
-           \end{tikzpicture} 
+
+           \end{tikzpicture}
         \end{center}
- 
+
     \end{enumerate}
 \end{frame}
 
@@ -198,7 +198,7 @@
 
         \pause
        \begin{center}
-           \begin{tikzpicture} 
+           \begin{tikzpicture}
                 \node (A) at (5, 5) { \footnotesize $tipo$ };
                 \node (B1) at (0, 3.75) { \footnotesize \code{pascal}{array} };
                 \node (B2) at (2, 3.75) { \footnotesize \code{pascal}{[} };
@@ -223,10 +223,10 @@
                 \draw[thick] (B3) to (C3);
                 \draw[thick] (B6) to (D1);
                 \draw[thick] (E1) to (D1);
-        
-           \end{tikzpicture} 
+
+           \end{tikzpicture}
         \end{center}
- 
+
     \end{enumerate}
 \end{frame}
 
@@ -258,7 +258,7 @@
     O procedimento \Call{reconhecer}{\,} confronta o valor de \textit{lookahead} e um determinado token. Em caso de coincidência, ele atualiza \textit{lookahead} com
     o próximo token da entrada.
     \pause
-    
+
     \vspace{0.2in}
     \begin{algorithmic}[1]
         \Procedure{reconhecer}{$token$}
@@ -323,14 +323,14 @@
     \end{block}
 
     \vspace{0.2in}
-    Por exemplo, na gramática de geração de subtipos em Pascal, 
+    Por exemplo, na gramática de geração de subtipos em Pascal,
 
     \begin{center}\Call{primeiro}{$primitivo$} = \{ \code{pascal}{integer, char, num} \}\end{center}
 
     e
 
     \begin{center}\Call{primeiro}{$\uparrow$\code{pascal}{id}} = \{ $\uparrow$ \}\end{center}
-    
+
 \end{frame}
 
 \begin{frame}[fragile]{Primeiros símbolos e análise gramatica preditiva}
@@ -339,11 +339,11 @@
         \item A análise gramatical preditiva depende dos conjuntos \Call{primeiro}{$X$} de todos não-terminais $X$ da gramática
         \pause
 
-        \item Isto acontece principalmente nos casos onde a gramática possui duas ou mais produções para um mesmo não-terminal (por exemplo, $A \to \alpha$ e 
+        \item Isto acontece principalmente nos casos onde a gramática possui duas ou mais produções para um mesmo não-terminal (por exemplo, $A \to \alpha$ e
         $A\to \beta$)
         \pause
 
-        \item Para rque a análise gramatical recursiva descendente seja preditiva é necessário que os primeiros símbolos de cada produção sejam distintos
+        \item Para que a análise gramatical recursiva descendente seja preditiva é necessário que os primeiros símbolos de cada produção sejam distintos
         \pause
 
         \item No exemplo dado,


### PR DESCRIPTION
**Observação:** Lembre de recompilar os pdfs, pois tem muitos erros de digitação já corrigidos no latex que permanecem nos pdfs.