### PR TITLE
Correções nos slides da aula de análise léxica

### DIFF
--- a/analise_lexica/codes/diagramas.cpp
+++ b/analise_lexica/codes/diagramas.cpp
@@ -13,7 +13,7 @@ map<int, vector<edge>> diagram {
     { 1, { { 2, match<'='> }, { 3, match<'>'> }, { 4, wildcard } } },
     { 6, { { 7, match<'='> }, { 8, wildcard } } },
     { 9, { { 10, isalpha } } },
-    { 10, { { 10, isalpha }, { 11, wildcard } } },
+    { 10, { { 10, isalnum }, { 11, wildcard } } },
     { 28, { { 29, isspace } } },
     { 29, { { 29, isspace }, { 30, wildcard } } },
 };

--- a/analise_lexica/codes/lex.l
+++ b/analise_lexica/codes/lex.l
@@ -14,7 +14,7 @@ ws      {delim}+
 letra   [A-Za-z]
 digito  [0-9]
 id      {letra}({letra}|{digito})*
-num     {digito}+(\.{digito}+)?(E[+-]?(digito)+)?
+num     {digito}+(\.{digito}+)?(E[+-]?{digito}+)?
 
 %%
 


### PR DESCRIPTION
## Correção 1
Acredito que para seguir a definição do diagrama de nó 9 a função de transição do nó 10 para o nó 10 deve utilizar a função `isalnum`, para que assim seja aceito digitos e letras, invés de somente letras.

![image](https://user-images.githubusercontent.com/31013187/181636867-db27bd1b-5dbb-4208-8c7e-ea3f14c8364c.png)

![image](https://user-images.githubusercontent.com/31013187/181637180-47ab2291-63e4-4880-96a0-870cdef44c1f.png)

## Correção 2
Acredito que o `(digito)` deveria ser `{digito}` na expressão regular que identificar o token `num`.

![image](https://user-images.githubusercontent.com/31013187/181651410-aa08059b-7781-48bb-930b-8727c554b539.png)

