### PR TITLE
fix: cadeia de "caracteres" ->  "tokens"

### DIFF
--- a/analise_sintatica/gramaticas.tex
+++ b/analise_sintatica/gramaticas.tex
@@ -6,7 +6,7 @@
         Uma gramática livre de contexto é composta por terminais, não-terminais, um símbolo de partida e produções, onde
         \begin{enumerate}
             \item os terminais (tokens) são símbolos básicos para a formação de cadeias;
-            \item os não-terminais são variáveis sintáticas que identificam cadeias de caracteres e que impõem uma estrutura hierárquica na linguagem;
+            \item os não-terminais são variáveis sintáticas que identificam cadeias de tokens e que impõem uma estrutura hierárquica na linguagem;
             \item um dentre os não-terminais é designado como símbolo de partida e o conjunto de cadeias geradas por ele é a linguagem definida pela gramática; e
             \item as produção estabelecem as relações entre terminais e não-terminais e como novas cadeias podem ser formadas. Cada produção é composta por um
                 não-terminal seguido de uma seta, a qual é sucedida por uma cadeia de terminais e não-terminais.


### PR DESCRIPTION
Corrigindo "cadeia de caracteres" para "cadeia de tokens" na definição de não-terminais.